### PR TITLE
Fixed Compilation Error

### DIFF
--- a/Action_GIGIST.cpp
+++ b/Action_GIGIST.cpp
@@ -182,7 +182,7 @@ Action::RetType Action_GIGist::Init(ArgList &argList, ActionInit &actionInit, in
     }
   }
 
-  mprintf("Center: %.1g %.1g %.1g, Dimensions %d %d %d\n"
+  mprintf("Center: %g %g %g, Dimensions %d %d %d\n"
           "  When using this GIST implementation please cite:\n"
           "#    Johannes Kraml, Anna S. Kamenik, Franz Waibl, Michael Schauperl, Klaus R. Liedl, JCTC (2019)\n"
           "#    Steven Ramsey, Crystal Nguyen, Romelia Salomon-Ferrer, Ross C. Walker, Michael K. Gilson, and Tom Kurtzman\n"

--- a/Action_GIGIST.cpp
+++ b/Action_GIGIST.cpp
@@ -47,6 +47,7 @@ doorder_(false)
 void Action_GIGist::Help() const {
   mprintf("     Usage:\n"
           "    griddim [dimx dimy dimz]   Defines the dimension of the grid.\n"
+          "    <gridcntr [x y z]>         Defines the center of the grid, default [0 0 0].\n"
           "    <temp 300>                 Defines the temperature of the simulation.\n"
           "    <gridspacn 0.5>            Defines the grid spacing\n"
           "    <refdens 0.0329>           Defines the reference density for the water model.\n"

--- a/Action_GIGIST.h
+++ b/Action_GIGIST.h
@@ -248,15 +248,45 @@ private:
   void calcTransEntropyDist(int, int, int, double &, double &);
 
   // In: Action_GIGIST.cpp
-  // line: 1031
+  // line: 1035
   int weight(std::string);
 
   // In: Action_GIGIST.cpp
-	// line: 1053
+	// line: 1058
   void writeDxFile(std::string, std::vector<double>);
 
 
   // Necessary Variables
+
+  // For CUDA use, store some more elements
+#ifdef CUDA
+  std::vector<float> lJParamsA_;
+  std::vector<float> lJParamsB_;
+  std::vector<int> NBIndex_;
+  int numberAtomTypes_;
+
+  // Arrays on GPU
+  int *NBindex_c_;
+  void *molecule_c_;
+  void *paramsLJ_c_;
+  float *max_c_;
+  float *min_c_;
+  float *result_w_c_;
+  float *result_s_c_;
+  int *result_O_c_;
+  int *result_N_c_;
+
+  // CUDA only functions
+
+  // In: Action_GIGIST.cpp
+  // line: 1087
+  void freeGPUMemory(void);
+
+  // In: Action_GIGIST.cpp
+  // line: 1112
+  void copyToGPU(void);
+
+#endif
 
   // Dataset pointer
   DataSetList *list_;
@@ -300,7 +330,7 @@ private:
   bool *solvent_;
   
   std::vector<std::vector<Vec3> > waterCoordinates_;
-  DataDictionary dict_ = DataDictionary();
+  DataDictionary dict_;
 
   CpptrajFile *datafile_;
   CpptrajFile *dxfile_;
@@ -316,35 +346,7 @@ private:
   Timer tEnergy_;
 
 
-  // For CUDA use, store some more elements
-#ifdef CUDA
-  std::vector<float> lJParamsA_;
-  std::vector<float> lJParamsB_;
-  std::vector<int> NBIndex_;
-  int numberAtomTypes_;
 
-  // Arrays on GPU
-  int *NBindex_c_   = NULL;
-  void *molecule_c_  = NULL;
-  void *paramsLJ_c_  = NULL;
-  float *max_c_     = NULL;
-  float *min_c_     = NULL;
-  float *result_w_c_= NULL;
-  float *result_s_c_= NULL;
-  int *result_O_c_  = NULL;
-  int *result_N_c_  = NULL;
-
-  // CUDA only functions
-
-  // In: Action_GIGIST.cpp
-  // line: 1082
-  void freeGPUMemory(void);
-
-  // In: Action_GIGIST.cpp
-  // line: 1107
-  void copyToGPU(void);
-
-#endif
 
 };
 

--- a/cuda_kernel_gist/GistCudaSetup.cu
+++ b/cuda_kernel_gist/GistCudaSetup.cu
@@ -242,7 +242,7 @@ std::vector<std::vector<float> > doActionCudaEnergy(const double *coords, int *N
 #ifdef DEBUG_GIST_CUDA
 // Not necessary
 __host__
-std::vector<Quaternion<float>> shoveQuaternionsTest(std::vector<Quaternion<float> > quats) {
+std::vector<Quaternion<float> > shoveQuaternionsTest(std::vector<Quaternion<float> > quats) {
   QuaternionG<float> *quats_c = NULL;
   float *ret_c = NULL;
   std::vector<Quaternion<float> > ret;
@@ -301,7 +301,7 @@ std::vector<Quaternion<float>> shoveQuaternionsTest(std::vector<Quaternion<float
  * @return: A vector holding the values for dTStrans, dTSorient and dTSsix.
  * @throws: A CudaException on error.
  */
-std::vector<std::vector<float> > doActionCudaEntropy(std::vector<std::vector<Vec3> > coords, int x, int y, int z, std::vector<std::vector<Quaternion<float> >> quats, float temp, float rho0, int nFrames) {
+std::vector<std::vector<float> > doActionCudaEntropy(std::vector<std::vector<Vec3> > coords, int x, int y, int z, std::vector<std::vector<Quaternion<float> > > quats, float temp, float rho0, int nFrames) {
   
   // For the CPU
   // Input (from previous calculations)

--- a/cuda_kernel_gist/GistCudaSetup.cuh
+++ b/cuda_kernel_gist/GistCudaSetup.cuh
@@ -25,6 +25,6 @@ std::vector<std::vector<float> > doActionCudaEnergy(const double *, int *, int ,
                             int , float *, float *, int , float *, 
                             float *, int, float, int *, int *, float *, float *,
                             int *, int *, bool);
-std::vector<std::vector<float> > doActionCudaEntropy(std::vector<std::vector<Vec3> >, int, int, int, std::vector<std::vector<Quaternion<float> >>, float, float, int);
+std::vector<std::vector<float> > doActionCudaEntropy(std::vector<std::vector<Vec3> >, int, int, int, std::vector<std::vector<Quaternion<float> > >, float, float, int);
 
 #endif


### PR DESCRIPTION
Close #1
Since C++11 it is not necessary to add spaces between closing brackets
of template arguments. In the spirit of compatibility however, the
spaces between those brackets have been added.